### PR TITLE
Fix NuGet badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ MSBuild.ConfuserEx
 MSBuild.ConfuserEx is a target for ConfuserEx integration in MSBuild process.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/melev7x8iigtmryx?svg=true)](https://ci.appveyor.com/project/ennerperez/confuserex)
-[![NuGet](https://img.shields.io/nuget/v/Nuget.Core.svg)](https://www.nuget.org/packages/MSBuild.ConfuserEx/)
+[![NuGet](https://img.shields.io/nuget/v/MSBuild.ConfuserEx.svg)](https://www.nuget.org/packages/MSBuild.ConfuserEx/)
 
 ConfuserEx
 ========


### PR DESCRIPTION
This change fixes the NuGet badge so it shows MSBuild.ConfuserEx package version (instead of Nuget.Core).